### PR TITLE
Ensure CSV informations are also present when claiming a gift

### DIFF
--- a/src/services/MysteryGiftService.ts
+++ b/src/services/MysteryGiftService.ts
@@ -93,7 +93,7 @@ export class MysteryGiftService {
     error?: string;
     gift?: Pick<
       MysteryGiftData,
-      'giftId' | 'title' | 'items' | 'creatures' | 'eggs'
+      'giftId' | 'title' | 'items' | 'creatures' | 'eggs' | 'csvDetails'
     >;
   }> {
     if (!code && !giftId)
@@ -137,6 +137,7 @@ export class MysteryGiftService {
         items: gift.items ?? [],
         creatures: gift.creatures ?? [],
         eggs: gift.eggs ?? [],
+        csvDetails: gift.csvDetails ?? undefined,
       },
     };
   }


### PR DESCRIPTION
# PR Description
Due to an oversight, the response received when claiming the gift didn't contain the csvDetails attribute. It is now fixed with this PR.