### PR TITLE
fix: run built server in Docker instead of dev/watch mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,9 @@ RUN npm install
 
 # Copy source and build
 COPY . .
+RUN npm run build
 
 # Logs directory (mounted as volume in compose)
 RUN mkdir -p logs
 
-CMD ["npm", "run", "dev"]
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ An in-process metrics store tracks request counts, error rates, WebSocket connec
 ├── .env.example
 ├── docker-compose.yml
 ├── docker-compose.server-only.yml
+├── docker-compose.dev.yml
 ├── Dockerfile
 ├── Dockerfile.mongodb
 ├── init_mongo.sh
@@ -211,6 +212,12 @@ docker compose up --build
 ```
 
 The server waits for MongoDB to pass its health check before starting. Data is persisted in a named Docker volume (`mongo_data`). Logs are persisted in `server_logs`.
+
+By default the container builds and runs the compiled server (`npm start`), same as a real deployment. For hot-reload during development, layer the dev override:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build
+```
 
 ### Docker (External MongoDB)
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,10 @@
+# Dev override: hot-reload via tsx watch instead of the built prod server.
+# Usage: docker compose -f docker-compose.yml -f docker-compose.dev.yml up
+services:
+  server:
+    command: npm run dev
+    environment:
+      - NODE_ENV=development
+    volumes:
+      - server_logs:/usr/src/app/logs
+      - ./src:/usr/src/app/src

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "build": "tsc",
-    "start": "node dist/index.js",
+    "start": "node dist/src/index.js",
     "docs": "echo 'Swagger UI available at http://localhost:3000/api-docs when server is running'",
     "test": "vitest run",
     "test:watch": "vitest",


### PR DESCRIPTION
The Dockerfile's CMD ran `npm run dev` (tsx watch) regardless of NODE_ENV, so anyone deploying via Docker Compose was unknowingly running the dev server in production. The image now builds the TypeScript and runs the compiled output via `npm start`.

Hot-reload for local Docker development is preserved via a new docker-compose.dev.yml override (`npm run dev`, source bind-mounted).